### PR TITLE
Migrate ROS Rolling images to ubuntu noble

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ All images are based on Ubuntu.
 | ros-base        | ✅     | ❌      | ✅        | `ghcr.io/sloretz/ros:rolling-ros-base`     |
 | desktop         | ✅     | ❌      | ✅        | `ghcr.io/sloretz/ros:rolling-desktop`      |
 | perception      | ✅     | ❌      | ✅        | `ghcr.io/sloretz/ros:rolling-perception`   |
-| simulation      | ✅     | ❌      | ✅        | `ghcr.io/sloretz/ros:rolling-simulation`   |
-| desktop-full    | ✅     | ❌      | ✅        | `ghcr.io/sloretz/ros:rolling-desktop-full` |
+| simulation      | ❌⚠️    | ❌      | ❌⚠️       | `ghcr.io/sloretz/ros:rolling-simulation`   |
+| desktop-full    | ❌⚠️    | ❌      | ❌⚠️       | `ghcr.io/sloretz/ros:rolling-desktop-full` |
 | [ROS Noetic](https://wiki.ros.org/noetic)                                                   |
 | ros-core        | ✅     | ✅      | ✅        | `ghcr.io/sloretz/ros:noetic-ros-core`      |
 | ros-base        | ✅     | ✅      | ✅        | `ghcr.io/sloretz/ros:noetic-ros-base`      |
@@ -59,6 +59,8 @@ All images are based on Ubuntu.
 | robot           | ✅     | ✅      | ✅        | `ghcr.io/sloretz/ros:noetic-robot`         |
 | viz             | ✅     | ✅      | ✅        | `ghcr.io/sloretz/ros:noetic-viz`           |
 
+
+❌⚠️ [ROS Rolling desktop-full and simulation images are not available for Ubuntu Noble](https://github.com/sloretz/ros_oci_images/issues/2), but are expected to be available in the future.
 
 ## Using with other OCI compatible tools
 

--- a/scripts/build_images.py
+++ b/scripts/build_images.py
@@ -301,7 +301,7 @@ def create_ros2_manifests(registry, name, ros_distro, set_of_images, push, dry_r
         "desktop_full",
     ]
     for attr in attrs:
-        if "rolling" != ros_distro and attr in ["desktop_full", "simulation"]:
+        if "rolling" == ros_distro and attr in ["desktop_full", "simulation"]:
             # TODO(https://github.com/sloretz/ros_oci_images/issues/2)
             continue
         suffix = attr.replace("_", "-")

--- a/scripts/build_images.py
+++ b/scripts/build_images.py
@@ -199,12 +199,14 @@ def build_ros2_images(
         images.ros_base, "ros2/perception", **common_args
     )
     images.desktop = _buildah_ros_image(images.ros_base, "ros2/desktop", **common_args)
-    images.desktop_full = _buildah_ros_image(
-        images.desktop, "ros2/desktop-full", **common_args
-    )
-    images.simulation = _buildah_ros_image(
-        images.ros_base, "ros2/simulation", **common_args
-    )
+    if "rolling" != ros_distro:
+        # TODO(https://github.com/sloretz/ros_oci_images/issues/2)
+        images.desktop_full = _buildah_ros_image(
+            images.desktop, "ros2/desktop-full", **common_args
+        )
+        images.simulation = _buildah_ros_image(
+            images.ros_base, "ros2/simulation", **common_args
+        )
 
     return images
 
@@ -310,7 +312,7 @@ ROS_DISTROS = {
     "noetic": "ubuntu:focal",
     "humble": "ubuntu:jammy",
     "iron": "ubuntu:jammy",
-    "rolling": "ubuntu:jammy",
+    "rolling": "ubuntu:noble",
 }
 
 

--- a/scripts/build_images.py
+++ b/scripts/build_images.py
@@ -301,6 +301,9 @@ def create_ros2_manifests(registry, name, ros_distro, set_of_images, push, dry_r
         "desktop_full",
     ]
     for attr in attrs:
+        if "rolling" != ros_distro and attr in ["desktop_full", "simulation"]:
+            # TODO(https://github.com/sloretz/ros_oci_images/issues/2)
+            continue
         suffix = attr.replace("_", "-")
         images = _collect(attr, set_of_images)
         _buildah_manifest(

--- a/scripts/test_images.py
+++ b/scripts/test_images.py
@@ -118,6 +118,9 @@ def main():
             ("arm64", "v8"),
         ]
         for s in suffixes:
+            if "rolling" == ros_distro and s in ["desktop-full", "simulation"]:
+                # TODO(https://github.com/sloretz/ros_oci_images/issues/2)
+                continue
             tag = f"{ros_distro}-{s}"
             package = f"ros-{ros_distro}-{s}"
             full_name = _full_name(args.registry, args.name, tag)


### PR DESCRIPTION
desktop-full and simulation aren't yet available for AMD 64, and lots of packages aren't available for arm64 v8 https://github.com/sloretz/ros_oci_images/issues/2