### PR TITLE
Remove some dead code in one action

### DIFF
--- a/.github/workflows/build-and-deploy-one-ros-distro.yaml
+++ b/.github/workflows/build-and-deploy-one-ros-distro.yaml
@@ -81,10 +81,6 @@ jobs:
             --push \
             --dry-run)
             echo "${output}"
-          manifests=$(echo "${output}" | grep MANIFEST | awk '{print $2}' | sort | uniq | tr '\n' ' ')
-          images=$(echo "${output}" | grep IMAGE | awk '{print $2}' | sort | uniq | tr '\n' ' ')
-          echo "manifests=${manifests}" >> "${GITHUB_OUTPUT}"
-          echo "images=${images}" >> "${GITHUB_OUTPUT}"
 
       - name: Build and Push Images
         run: |


### PR DESCRIPTION
This was used when I used a separate action for pushing images an manifests, but is no longer required now that the build_images.py script does the pushing.