### PR TITLE
Auto add remoteUser in devcontainer.metadata

### DIFF
--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -93,3 +93,11 @@ UBUNTU_DEV_IMAGE:
         colcon metadata add default \
         https://raw.githubusercontent.com/colcon/colcon-metadata-repository/master/index.yaml && \
         colcon metadata update
+
+    LABEL devcontainer.metadata=" \
+        [ \
+            { \
+                \"remoteUser\": \"ros\", \
+                \"capAdd\": [\"SYS_PTRACE\"] \
+            } \
+        ]"

--- a/ros-dev/README.md
+++ b/ros-dev/README.md
@@ -31,9 +31,7 @@ Follow these instructions to create a dev container from one of these images.
 1. Specify the image you want to use in the `devcontainer.json` file using this template.
    ```json
     {
-        "name": "My Dev Container",
-        "image": "ghcr.io/sloretz/ros-dev:ubuntu-noble",
-        "remoteUser": "ros"
+        "image": "ghcr.io/sloretz/ros-dev:ubuntu-noble"
     }
     ```
 1. Open [VS Code](https://code.visualstudio.com/)
@@ -63,9 +61,7 @@ Follow these instructions to build ROS from source inside one of these images:
 1. Specify the image you want to use in the `devcontainer.json` file using this template.
    ```json
     {
-        "name": "ROS Roling from source",
-        "image": "ghcr.io/sloretz/ros-dev:ubuntu-noble",
-        "remoteUser": "ros"
+        "image": "ghcr.io/sloretz/ros-dev:ubuntu-noble"
     }
     ```
 1. Enter the dev container as described above


### PR DESCRIPTION
Automatically set it so it doesn't have to be specified in `devcontainer.json`.