### PR TITLE
Retry API requests to try to get the latest tag for the apt source deb

### DIFF
--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -36,8 +36,8 @@ UBUNTU_DEV_IMAGE:
 
     # Setup keys and apt sources
     RUN set -eux; \
-        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | jq -r ".tag_name"); \
-        curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
+        export ROS_APT_SOURCE_VERSION=$(curl --retry 5 -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | jq -r ".tag_name"); \
+        curl --retry 5 -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
         apt install /tmp/ros2-apt-source.deb; \
         rm /tmp/ros2-apt-source.deb
 

--- a/ros2/Earthfile
+++ b/ros2/Earthfile
@@ -95,11 +95,11 @@ ros-core:
 
     # Setup keys and apt sources
     RUN set -eux; \
-        export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | jq -r ".tag_name"); \
+        export ROS_APT_SOURCE_VERSION=$(curl --retry 5 -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | jq -r ".tag_name"); \
         if [ "${use_testing_repo}" = "true" ]; then \
-            curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-testing-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
+            curl --retry 5 -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-testing-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
         else \
-            curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
+            curl --retry 5 -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
         fi ; \
         apt install /tmp/ros2-apt-source.deb; \
         rm /tmp/ros2-apt-source.deb


### PR DESCRIPTION
Looking at https://github.com/sloretz/ros_oci_images/actions/runs/15500395051/job/43646747299 , it seems sometimes the API request https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest returns nothing in the ros-dev jobs. I'm not sure why that is, so I'm adding retry logic here.