### PR TITLE
Fix missing type

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -30,6 +30,7 @@ on:
       earthly_target:
         description: The earthly target to build including a '+' sign at the start.
         required: true
+        type: string
 
 permissions:
       packages: write


### PR DESCRIPTION
```
Invalid workflow file: .github/workflows/build-dev-ubuntu-jammy.yaml#L14
The workflow is not valid. In .github/workflows/build-dev-ubuntu-jammy.yaml (Line: 14, Col: 11): Error from called workflow sloretz/ros_oci_images/.github/workflows/build-dev.yaml@c9e2ac7ce9376470a8ef9324dd9a344903d7cba5 (Line: 31, Col: 9): Required property is missing: type
```