### PR TITLE
Add Ubuntu Resolute dev container images

### DIFF
--- a/.github/workflows/build-dev-ubuntu-resolute.yaml
+++ b/.github/workflows/build-dev-ubuntu-resolute.yaml
@@ -1,0 +1,17 @@
+name: Build Dev Ubuntu Resolute
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # Every day at 00:00 while resolute is under heavy development
+    # - cron: '0 0 * * SUN'  # 00:00 on Sunday.
+
+permissions:
+      packages: write
+      contents: read
+
+jobs:
+  build-dev-ubuntu-resolute:
+    uses: ./.github/workflows/build-dev.yaml
+    with:
+      earthly_target: +ros-dev-ubuntu-resolute

--- a/.github/workflows/build-dev-ubuntu-resolute.yaml
+++ b/.github/workflows/build-dev-ubuntu-resolute.yaml
@@ -3,8 +3,7 @@ name: Build Dev Ubuntu Resolute
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'  # Every day at 00:00 while resolute is under heavy development
-    # - cron: '0 0 * * SUN'  # 00:00 on Sunday.
+    - cron: '0 0 * * SUN'  # 00:00 on Sunday.
 
 permissions:
       packages: write

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -14,6 +14,7 @@ on:
       earthly_target:
         type: choice
         options:
+          - "+ros-dev-ubuntu-resolute-multiarch"
           - "+ros-dev-ubuntu-noble-multiarch"
           - "+ros-dev-ubuntu-jammy-multiarch"
         description: The earthly target to build including a '+' sign at the start.

--- a/.github/workflows/ci-amd64-ubuntu-resolute.yaml
+++ b/.github/workflows/ci-amd64-ubuntu-resolute.yaml
@@ -1,0 +1,22 @@
+name: CI AMD64 Dev Container (Ubuntu Resolute)
+
+on:
+  pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci-build-amd64-dev-image-resolute:
+    name: CI AMD64 Dev Container (Ubuntu Resolute)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: earthly/actions-setup@43211c7a0eae5344d6d79fb4aaf209c8f8866203  # v1.0.13
+        with:
+          version: v0.8.0
+      - name: Checkout Repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      - name: Build Image
+        run: |
+          earthly --ci +ros-dev-ubuntu-resolute

--- a/Earthfile
+++ b/Earthfile
@@ -26,6 +26,10 @@ humble:
     ARG image_name='ros'
     BUILD --pass-args ros2+humble
 
+ros-dev-ubuntu-resolute:
+    ARG registry='localhost/'
+    ARG image_name='ros-dev'
+    BUILD --pass-args ros-dev+ubuntu-resolute
 
 ros-dev-ubuntu-noble:
     ARG registry='localhost/'
@@ -62,6 +66,10 @@ humble-multiarch:
     ARG image_name='ros'
     BUILD --pass-args --platform=linux/amd64 --platform=linux/arm64/v8 +humble
 
+ros-dev-ubuntu-resolute-multiarch:
+    ARG registry='localhost/'
+    ARG image_name='ros-dev'
+    BUILD --pass-args --platform=linux/amd64 --platform=linux/arm/v7 --platform=linux/arm64/v8 +ros-dev-ubuntu-resolute
 
 ros-dev-ubuntu-noble-multiarch:
     ARG registry='localhost/'

--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -45,7 +45,7 @@ UBUNTU_DEV_IMAGE:
     # Setup keys and apt sources
     IF [ "$MANUAL_ROS_APT_KEY" = "true" ]
         RUN set -eux; \
-        curl --retry 5 -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+        curl --retry 5 -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
     ELSE
     RUN set -eux; \

--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -96,7 +96,7 @@ UBUNTU_DEV_IMAGE:
 
     IF [ "$bootstrap" = "pip" ]
         RUN set -eux; \
-            pip install --user \
+            pip install --user --break-system-packages \
                 bloom \
                 colcon-common-extensions \
                 colcon-mixin \

--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -6,7 +6,8 @@ IMPORT ../lib AS lib
 ubuntu-resolute:
     ARG image_name='ros-dev'
     ARG registry='localhost/'
-    DO +UBUNTU_DEV_IMAGE --UBUNTU_IMAGE=ubuntu:resolute
+    # TODO use ros-apt-source package when available
+    DO +UBUNTU_DEV_IMAGE --UBUNTU_IMAGE=ubuntu:resolute --MANUAL_ROS_APT_KEY=true
     DO lib+SAVE_IMAGE_AND_DATE --fully_qualified_name=${registry}${image_name}:ubuntu-resolute
 
 ubuntu-noble:
@@ -26,6 +27,7 @@ ubuntu-jammy:
 UBUNTU_DEV_IMAGE:
     FUNCTION
     ARG --required UBUNTU_IMAGE
+    ARG MANUAL_ROS_APT_KEY=false
     FROM ${UBUNTU_IMAGE}
 
     # Setup timezone
@@ -41,11 +43,17 @@ UBUNTU_DEV_IMAGE:
         sudo"
 
     # Setup keys and apt sources
+    IF [ "$MANUAL_ROS_APT_KEY" = "true" ]
+        RUN set -eux; \
+        curl --retry 5 -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+    ELSE
     RUN set -eux; \
         export ROS_APT_SOURCE_VERSION=$(curl --retry 5 -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | jq -r ".tag_name"); \
         curl --retry 5 -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
         apt install /tmp/ros2-apt-source.deb; \
         rm /tmp/ros2-apt-source.deb
+    END
 
     # Setup environment
     ENV LANG C.UTF-8

--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -7,7 +7,7 @@ ubuntu-resolute:
     ARG image_name='ros-dev'
     ARG registry='localhost/'
     # TODO use ros-apt-source package when available
-    DO +UBUNTU_DEV_IMAGE --UBUNTU_IMAGE=ubuntu:resolute --MANUAL_ROS_APT_KEY=true
+    DO +UBUNTU_DEV_IMAGE --UBUNTU_IMAGE=ubuntu:resolute --bootstrap=pip
     DO lib+SAVE_IMAGE_AND_DATE --fully_qualified_name=${registry}${image_name}:ubuntu-resolute
 
 ubuntu-noble:
@@ -27,7 +27,7 @@ ubuntu-jammy:
 UBUNTU_DEV_IMAGE:
     FUNCTION
     ARG --required UBUNTU_IMAGE
-    ARG MANUAL_ROS_APT_KEY=false
+    ARG bootstrap=apt
     FROM ${UBUNTU_IMAGE}
 
     # Setup timezone
@@ -43,16 +43,16 @@ UBUNTU_DEV_IMAGE:
         sudo"
 
     # Setup keys and apt sources
-    IF [ "$MANUAL_ROS_APT_KEY" = "true" ]
-        RUN set -eux; \
-        curl --retry 5 -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-    ELSE
+    IF [ "$bootstrap" = "apt" ]
     RUN set -eux; \
         export ROS_APT_SOURCE_VERSION=$(curl --retry 5 -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | jq -r ".tag_name"); \
         curl --retry 5 -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
         apt install /tmp/ros2-apt-source.deb; \
         rm /tmp/ros2-apt-source.deb
+    ELSE
+    RUN set -eux; \
+        curl --retry 5 -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
     END
 
     # Setup environment
@@ -60,6 +60,7 @@ UBUNTU_DEV_IMAGE:
     ENV LC_ALL C.UTF-8
 
     # Install ROS Developer tools
+    IF [ "$bootstrap" = "apt" ]
     DO apt+INSTALL --packages="
         python3-pip
         python3-pytest-cov
@@ -70,9 +71,7 @@ UBUNTU_DEV_IMAGE:
         python3-pytest-rerunfailures
         ros-dev-tools
         python3-colcon-mixin"
-
-    # Bootstrap rosdep
-    RUN rosdep init
+    END
 
     # Create a non-root user
     # https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
@@ -91,7 +90,19 @@ UBUNTU_DEV_IMAGE:
     # Set the default user.
     USER $USERNAME
 
-    # Update rosdep
+    IF [ "$bootstrap" = "pip" ]
+    DO apt+INSTALL --packages="python3-pip"
+    RUN set -eux; \
+        pip install --user \
+            bloom \
+            colcon-common-extensions \
+            colcon-mixin \
+            rosdep \
+            vcs2l
+    END
+
+    # Bootstrap rosdep
+    RUN sudo rosdep init
     RUN rosdep update
 
     # Setup colcon mixin and metadata

--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -44,15 +44,15 @@ UBUNTU_DEV_IMAGE:
 
     # Setup keys and apt sources
     IF [ "$bootstrap" = "apt" ]
-    RUN set -eux; \
-        export ROS_APT_SOURCE_VERSION=$(curl --retry 5 -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | jq -r ".tag_name"); \
-        curl --retry 5 -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
-        apt install /tmp/ros2-apt-source.deb; \
-        rm /tmp/ros2-apt-source.deb
+        RUN set -eux; \
+            export ROS_APT_SOURCE_VERSION=$(curl --retry 5 -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | jq -r ".tag_name"); \
+            curl --retry 5 -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
+            apt install /tmp/ros2-apt-source.deb; \
+            rm /tmp/ros2-apt-source.deb
     ELSE
-    RUN set -eux; \
-        curl --retry 5 -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+        RUN set -eux; \
+            curl --retry 5 -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
     END
 
     # Setup environment
@@ -61,17 +61,21 @@ UBUNTU_DEV_IMAGE:
 
     # Install ROS Developer tools
     IF [ "$bootstrap" = "apt" ]
-    DO apt+INSTALL --packages="
-        python3-pip
-        python3-pytest-cov
-        python3-flake8-blind-except
-        python3-flake8-class-newline
-        python3-flake8-deprecated
-        python3-pytest-repeat
-        python3-pytest-rerunfailures
-        ros-dev-tools
-        python3-colcon-mixin"
+        DO apt+INSTALL --packages="
+            python3-pip
+            python3-pytest-cov
+            python3-flake8-blind-except
+            python3-flake8-class-newline
+            python3-flake8-deprecated
+            python3-pytest-repeat
+            python3-pytest-rerunfailures
+            ros-dev-tools
+            python3-colcon-mixin"
     END
+    IF [ "$bootstrap" = "pip" ]
+        DO apt+INSTALL --packages="python3-pip"
+    END
+
 
     # Create a non-root user
     # https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
@@ -91,14 +95,13 @@ UBUNTU_DEV_IMAGE:
     USER $USERNAME
 
     IF [ "$bootstrap" = "pip" ]
-    DO apt+INSTALL --packages="python3-pip"
-    RUN set -eux; \
-        pip install --user \
-            bloom \
-            colcon-common-extensions \
-            colcon-mixin \
-            rosdep \
-            vcs2l
+        RUN set -eux; \
+            pip install --user \
+                bloom \
+                colcon-common-extensions \
+                colcon-mixin \
+                rosdep \
+                vcs2l
     END
 
     # Bootstrap rosdep

--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -7,7 +7,7 @@ ubuntu-resolute:
     ARG image_name='ros-dev'
     ARG registry='localhost/'
     # TODO use ros-apt-source package when available
-    DO +UBUNTU_DEV_IMAGE --UBUNTU_IMAGE=ubuntu:resolute --bootstrap=pip
+    DO +UBUNTU_DEV_IMAGE --UBUNTU_IMAGE=ubuntu:resolute
     DO lib+SAVE_IMAGE_AND_DATE --fully_qualified_name=${registry}${image_name}:ubuntu-resolute
 
 ubuntu-noble:
@@ -27,7 +27,6 @@ ubuntu-jammy:
 UBUNTU_DEV_IMAGE:
     FUNCTION
     ARG --required UBUNTU_IMAGE
-    ARG bootstrap=apt
     FROM ${UBUNTU_IMAGE}
 
     # Setup timezone
@@ -43,39 +42,27 @@ UBUNTU_DEV_IMAGE:
         sudo"
 
     # Setup keys and apt sources
-    IF [ "$bootstrap" = "apt" ]
-        RUN set -eux; \
-            export ROS_APT_SOURCE_VERSION=$(curl --retry 5 -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | jq -r ".tag_name"); \
-            curl --retry 5 -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
-            apt install /tmp/ros2-apt-source.deb; \
-            rm /tmp/ros2-apt-source.deb
-    ELSE
-        RUN set -eux; \
-            curl --retry 5 -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg ; \
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-    END
+    RUN set -eux; \
+        export ROS_APT_SOURCE_VERSION=$(curl --retry 5 -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | jq -r ".tag_name"); \
+        curl --retry 5 -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(lsb_release -sc)_all.deb"; \
+        apt install /tmp/ros2-apt-source.deb; \
+        rm /tmp/ros2-apt-source.deb
 
     # Setup environment
     ENV LANG C.UTF-8
     ENV LC_ALL C.UTF-8
 
     # Install ROS Developer tools
-    IF [ "$bootstrap" = "apt" ]
-        DO apt+INSTALL --packages="
-            python3-pip
-            python3-pytest-cov
-            python3-flake8-blind-except
-            python3-flake8-class-newline
-            python3-flake8-deprecated
-            python3-pytest-repeat
-            python3-pytest-rerunfailures
-            ros-dev-tools
-            python3-colcon-mixin"
-    END
-    IF [ "$bootstrap" = "pip" ]
-        DO apt+INSTALL --packages="python3-pip"
-    END
-
+    DO apt+INSTALL --packages="
+        python3-pip
+        python3-pytest-cov
+        python3-flake8-blind-except
+        python3-flake8-class-newline
+        python3-flake8-deprecated
+        python3-pytest-repeat
+        python3-pytest-rerunfailures
+        ros-dev-tools
+        python3-colcon-mixin"
 
     # Create a non-root user
     # https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
@@ -93,16 +80,6 @@ UBUNTU_DEV_IMAGE:
 
     # Set the default user.
     USER $USERNAME
-
-    IF [ "$bootstrap" = "pip" ]
-        RUN set -eux; \
-            pip install --user --break-system-packages \
-                bloom \
-                colcon-common-extensions \
-                colcon-mixin \
-                rosdep \
-                vcs2l
-    END
 
     # Bootstrap rosdep
     RUN sudo --preserve-env rosdep init

--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -3,6 +3,12 @@ VERSION 0.8
 IMPORT ../apt AS apt
 IMPORT ../lib AS lib
 
+ubuntu-resolute:
+    ARG image_name='ros-dev'
+    ARG registry='localhost/'
+    DO +UBUNTU_DEV_IMAGE --UBUNTU_IMAGE=ubuntu:resolute
+    DO lib+SAVE_IMAGE_AND_DATE --fully_qualified_name=${registry}${image_name}:ubuntu-resolute
+
 ubuntu-noble:
     ARG image_name='ros-dev'
     ARG registry='localhost/'

--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -105,7 +105,7 @@ UBUNTU_DEV_IMAGE:
     END
 
     # Bootstrap rosdep
-    RUN sudo rosdep init
+    RUN sudo --preserve-env rosdep init
     RUN rosdep update
 
     # Setup colcon mixin and metadata

--- a/ros-dev/Earthfile
+++ b/ros-dev/Earthfile
@@ -6,7 +6,6 @@ IMPORT ../lib AS lib
 ubuntu-resolute:
     ARG image_name='ros-dev'
     ARG registry='localhost/'
-    # TODO use ros-apt-source package when available
     DO +UBUNTU_DEV_IMAGE --UBUNTU_IMAGE=ubuntu:resolute
     DO lib+SAVE_IMAGE_AND_DATE --fully_qualified_name=${registry}${image_name}:ubuntu-resolute
 


### PR DESCRIPTION
Part of #36 - but with some hacks:

* This builds the Resolute images every day at midnight (should be once a week post-release)
* There is no apt repo for resolute yet